### PR TITLE
Add empty-state message to file tree when no workspace is open

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,96 +1,99 @@
 <!doctype html>
 <html>
-<head>
-  <meta charset="utf-8" />
-  <title>SnapDock</title>
-  <link rel="stylesheet" href="src/styles/index.css" />
-</head>
-<body class="light-theme">
-  <div class="app-wrapper">
-
-    <header class="top-header">
-      <div class="header-left">
-        <button id="newFileBtn">New</button>
-        <button id="openFileBtnTop">Open File</button>
-        <button id="openFolderBtnTop">Open Folder</button>
-        <div class="divider"></div> <button id="saveFileBtnTop">Save</button>
-        <button id="exportPdfBtn">Export</button>
-      </div>
-    
-      <div class="header-center">
-        <div id="filenameWrapper">
-          <span id="workspaceName">Workspace</span>
+  <head>
+    <meta charset="utf-8" />
+    <title>SnapDock</title>
+    <link rel="stylesheet" href="src/styles/index.css" />
+  </head>
+  <body class="light-theme">
+    <div class="app-wrapper">
+      <header class="top-header">
+        <div class="header-left">
+          <button id="newFileBtn">New</button>
+          <button id="openFileBtnTop">Open File</button>
+          <button id="openFolderBtnTop">Open Folder</button>
+          <div class="divider"></div>
+          <button id="saveFileBtnTop">Save</button>
+          <button id="exportPdfBtn">Export</button>
         </div>
-      </div>
-    
-      <div class="header-right">
-        <button id="previewToggleBtn">Preview</button>
-      </div>
-    </header>
 
-    <!-- TAB BAR (moved here) -->
-    <div id="tabBar" class="tab-bar"></div>
-
-    <!-- MAIN APP CONTAINER -->
-    <div class="app-container">
-
-      <aside class="sidebar-left" id="sidebar">
-        <div class="recent-files">
-          <h3>Recent Files</h3>
-          <ul id="recentFilesList"></ul>
-        </div>
-        <div class="file-tree">
-          <h3>Project Files</h3>
-          <ul id="fileTreeList"></ul>
-        </div>
-        <div class="resizer" id="resizer"></div>
-      </aside>
-
-      <main class="workspace">
-        <section class="editor-bubble">
-        
-          <div class="editor-wrapper">
-            <textarea id="markdownInputMain" placeholder="# Welcome to SnapDock"></textarea>
+        <div class="header-center">
+          <div id="filenameWrapper">
+            <span id="workspaceName">Workspace</span>
           </div>
-        
-          <div class="preview-wrapper">
-            <div class="preview-inner">
-              <section id="previewMain" class="markdown-preview"></section>
+        </div>
+
+        <div class="header-right">
+          <button id="previewToggleBtn">Preview</button>
+        </div>
+      </header>
+
+      <!-- TAB BAR (moved here) -->
+      <div id="tabBar" class="tab-bar"></div>
+
+      <!-- MAIN APP CONTAINER -->
+      <div class="app-container">
+        <aside class="sidebar-left" id="sidebar">
+          <div class="recent-files">
+            <h3>Recent Files</h3>
+            <ul id="recentFilesList"></ul>
+          </div>
+          <div class="file-tree">
+            <h3>Project Files</h3>
+
+            <div id="fileTreeEmptyState" class="file-tree-empty">
+              Open a folder to begin working
+            </div>
+
+            <ul id="fileTreeList"></ul>
+          </div>
+
+          <div class="resizer" id="resizer"></div>
+        </aside>
+
+        <main class="workspace">
+          <section class="editor-bubble">
+            <div class="editor-wrapper">
+              <textarea
+                id="markdownInputMain"
+                placeholder="# Welcome to SnapDock"
+              ></textarea>
+            </div>
+
+            <div class="preview-wrapper">
+              <div class="preview-inner">
+                <section id="previewMain" class="markdown-preview"></section>
+              </div>
+            </div>
+          </section>
+        </main>
+      </div>
+
+      <footer class="footer">
+        <div class="footer-left">
+          <button id="helpBtn">Help</button>
+
+          <div class="theme-selector">
+            <button id="themeBtn">Theme</button>
+            <div class="theme-menu" id="themeMenu">
+              <button data-theme="light">Light</button>
+              <button data-theme="dark">Dark</button>
+              <button data-theme="solarized">Solarized</button>
+              <button data-theme="arctic">Arctic Dark</button>
             </div>
           </div>
-        
-        </section>
-      </main>
+        </div>
 
+        <div class="footer-center">
+          <span id="versionTag" class="version"></span>
+        </div>
+
+        <div class="footer-right">
+          <button id="update">Update</button>
+        </div>
+      </footer>
     </div>
 
-
-    <footer class="footer">
-      <div class="footer-left">
-        <button id="helpBtn">Help</button>
-
-        <div class="theme-selector">
-          <button id="themeBtn">Theme</button>
-          <div class="theme-menu" id="themeMenu">
-            <button data-theme="light">Light</button>
-            <button data-theme="dark">Dark</button>
-            <button data-theme="solarized">Solarized</button>
-            <button data-theme="arctic">Arctic Dark</button>
-          </div>
-        </div>
-      </div>
-
-      <div class="footer-center">
-        <span id="versionTag" class="version"></span>
-      </div>
-
-      <div class="footer-right">
-        <button id="update">Update</button>
-      </div>
-    </footer>
-
-  </div>
-
-  <script src="dist/bundle.js"></script>
-</body>
+    <script src="dist/bundle.js"></script>
+  </body>
 </html>

--- a/src/modules/file/tree.js
+++ b/src/modules/file/tree.js
@@ -23,6 +23,7 @@ export function initFileTree(container) {
 // ------------------------------------------------------------------
 // Render directory contents (container MUST be a <ul>)
 export async function renderFileTree(container, dirPath) {
+  const emptyState = document.getElementById("fileTreeEmptyState");
   const entries = await window.electronAPI.listFiles(dirPath);
 
   for (const entry of entries) {
@@ -36,17 +37,14 @@ export async function renderFileTree(container, dirPath) {
 
       li.addEventListener("click", async (e) => {
         e.stopPropagation();
-
         li.classList.toggle("open");
         nested.style.display = li.classList.contains("open") ? "block" : "none";
 
-        // Lazy-load folder contents
         if (nested.childElementCount === 0) {
           await renderFileTree(nested, entry.fullPath);
         }
       });
     } else {
-      // File click
       li.addEventListener("click", async (e) => {
         e.stopPropagation();
         await handleFileOpen(entry.fullPath, entry.name);
@@ -54,5 +52,12 @@ export async function renderFileTree(container, dirPath) {
     }
 
     container.appendChild(li);
+  }
+
+  // Empty-state toggle
+  if (container.childElementCount === 0) {
+    emptyState.style.display = "block";
+  } else {
+    emptyState.style.display = "none";
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -360,3 +360,11 @@ button:active {
   border-color: #b52b27;
 }
   */
+
+.file-tree-empty {
+  font-size: 0.85rem;
+  color: #888;
+  padding: 12px;
+  text-align: center;
+  opacity: 0.8;
+}


### PR DESCRIPTION
Fixes #30

Adds a friendly empty-state message to the file tree panel when no workspace
is open, guiding users to open a folder.

Testing:
- Verified message appears on app launch with no folder open
- Message hides automatically when a folder with files is opened
- Message remains visible for empty folders
