### PR TITLE
fix: Added close button to help popup

### DIFF
--- a/src/modules/ui/help.js
+++ b/src/modules/ui/help.js
@@ -9,16 +9,21 @@ export function initHelp() {
     const modal = document.createElement("div");
     modal.className = "modal";
     modal.innerHTML = `
-      <div class="modal-content">
-        ${md}
-        <button id="closeHelp">Close</button>
+      <div class="modal-content modal-content--help">
+        <div class="modal-close-float-wrap">
+          <button type="button" id="closeHelpFloat" class="modal-close-float" aria-label="Close">×</button>
+        </div>
+        <div class="modal-help-body">
+          ${md}
+          <button type="button" id="closeHelp">Close</button>
+        </div>
       </div>
     `;
 
     document.body.appendChild(modal);
 
-    document.getElementById("closeHelp").addEventListener("click", () => {
-      modal.remove();
-    });
+    const closeModal = () => modal.remove();
+    document.getElementById("closeHelpFloat").addEventListener("click", closeModal);
+    document.getElementById("closeHelp").addEventListener("click", closeModal);
   });
 }

--- a/src/styles/components/modal.css
+++ b/src/styles/components/modal.css
@@ -23,6 +23,46 @@
   overflow-y: auto;
 }
 
+/* Help modal: floating close button (stays visible when scrolling) */
+.modal-content--help {
+  padding-top: 0;
+}
+
+.modal-close-float-wrap {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-start;
+  margin: 0 -24px 16px -24px;
+  padding: 24px 16px 0 24px;
+  background: var(--workspace-bg);
+  min-height: 56px;
+  box-sizing: border-box;
+}
+
+.modal-close-float {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  font-size: 1.5rem;
+  line-height: 1;
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.4));
+  border-radius: 50%;
+  background: var(--workspace-bg);
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.modal-close-float:hover {
+  background: var(--hover-bg, rgba(128, 128, 128, 0.15));
+}
+
 /* ============================
    SnapDock Update System Styles
    ============================ */


### PR DESCRIPTION
Close #31 

Added new close button into Top Left in help popup. 

<img width="740" height="682" alt="image" src="https://github.com/user-attachments/assets/f7157a17-3c1a-4a14-bad8-0b51978c60df" />
