### PR TITLE
Add tab drag-and-drop reordering + preview mode dropdown (closes #84, #85)

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,28 @@
         </div>
 
         <div class="header-right">
-          <button id="previewToggleBtn">Preview</button>
+          <div class="preview-mode-dropdown" id="previewModeDropdown">
+            <button class="preview-mode-btn" id="previewToggleBtn">
+              <span id="previewModeLabel">Show Preview</span>
+              <span class="dropdown-arrow">▾</span>
+            </button>
+            <div class="preview-mode-menu" id="previewModeMenu">
+              <button class="preview-mode-option active" data-mode="preview">
+                <span class="option-check">✓</span>
+                <span class="option-label">Show Preview</span>
+              </button>
+              <button class="preview-mode-option disabled" data-mode="split">
+                <span class="option-check">✓</span>
+                <span class="option-label">Split View</span>
+                <span class="option-badge">soon</span>
+              </button>
+              <button class="preview-mode-option disabled" data-mode="live">
+                <span class="option-check">✓</span>
+                <span class="option-label">Live View</span>
+                <span class="option-badge">soon</span>
+              </button>
+            </div>
+          </div>
         </div>
       </header>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -399,6 +399,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -420,6 +421,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -436,6 +438,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -450,6 +453,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1218,7 +1222,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
@@ -1235,7 +1240,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -1338,7 +1344,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2076,7 +2081,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2370,7 +2376,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -2583,6 +2588,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -2603,6 +2609,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -3752,7 +3759,6 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -4073,6 +4079,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -4367,7 +4374,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4397,6 +4403,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -4414,6 +4421,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -4641,6 +4649,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -5030,6 +5039,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"

--- a/src/modules/file/tabs.js
+++ b/src/modules/file/tabs.js
@@ -107,6 +107,59 @@ export async function closeTab(tabId) {
 }
 
 /**
+ * Move a tab from one index to another (drag & drop)
+ */
+export function moveTab(fromIndex, toIndex) {
+  if (fromIndex === toIndex) return;
+  if (fromIndex < 0 || fromIndex >= tabs.length) return;
+  if (toIndex < 0 || toIndex >= tabs.length) return;
+
+  const [moved] = tabs.splice(fromIndex, 1);
+  tabs.splice(toIndex, 0, moved);
+  renderTabs();
+}
+
+// --- Drag & Drop state ---
+let dragState = {
+  dragging: null,     // index of tab being dragged
+  dropTarget: null,   // index of drop position
+  startX: 0,
+  placeholder: null,
+};
+
+/**
+ * Create a visual placeholder element for drop position
+ */
+function createDropPlaceholder() {
+  const el = document.createElement("div");
+  el.className = "tab-drop-indicator";
+  return el;
+}
+
+/**
+ * Get tab index from a mouse event by finding the nearest tab element
+ */
+function getTabIndexFromEvent(e, tabBar) {
+  const tabEls = Array.from(tabBar.querySelectorAll(".tab"));
+  if (tabEls.length === 0) return -1;
+
+  const mouseX = e.clientX;
+  let targetIndex = 0;
+
+  for (let i = 0; i < tabEls.length; i++) {
+    const rect = tabEls[i].getBoundingClientRect();
+    const midX = rect.left + rect.width / 2;
+    if (mouseX < midX) {
+      targetIndex = i;
+      break;
+    }
+    targetIndex = i + 1;
+  }
+
+  return targetIndex;
+}
+
+/**
  * Render tab bar
  */
 export function renderTabs() {
@@ -115,12 +168,13 @@ export function renderTabs() {
 
   tabBar.innerHTML = "";
 
-  tabs.forEach(tab => {
+  tabs.forEach((tab, index) => {
     const isActive = tab.id === activeTabId;
 
     const el = document.createElement("div");
     el.className = `tab ${isActive ? "active" : ""} ${tab.isDirty ? "dirty" : ""}`;
     el.dataset.tabId = tab.id;
+    el.draggable = true;
 
     // Status LED
     const led = document.createElement("div");
@@ -140,6 +194,81 @@ export function renderTabs() {
     close.addEventListener("click", e => {
       e.stopPropagation();
       closeTab(tab.id);
+    });
+
+    // --- Drag & Drop event handlers ---
+    el.addEventListener("dragstart", (e) => {
+      dragState.dragging = index;
+      el.classList.add("dragging");
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", tab.id);
+      // Hide default drag image
+      const ghost = document.createElement("div");
+      ghost.style.position = "absolute";
+      ghost.style.top = "-9999px";
+      document.body.appendChild(ghost);
+      e.dataTransfer.setDragImage(ghost, 0, 0);
+      setTimeout(() => ghost.remove(), 0);
+    });
+
+    el.addEventListener("dragend", () => {
+      el.classList.remove("dragging");
+      // Remove all indicators
+      tabBar.querySelectorAll(".tab-drop-indicator").forEach(el => el.remove());
+      dragState.dragging = null;
+      dragState.dropTarget = null;
+    });
+
+    el.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      if (dragState.dragging === null || dragState.dragging === index) return;
+
+      e.dataTransfer.dropEffect = "move";
+
+      // Remove old indicators
+      tabBar.querySelectorAll(".tab-drop-indicator").forEach(el => el.remove());
+
+      // Determine drop side based on cursor position relative to tab center
+      const rect = el.getBoundingClientRect();
+      const midX = rect.left + rect.width / 2;
+      const dropAfter = e.clientX > midX;
+
+      const indicator = createDropPlaceholder();
+      if (dropAfter) {
+        el.insertAdjacentElement("afterend", indicator);
+      } else {
+        el.insertAdjacentElement("beforebegin", indicator);
+      }
+    });
+
+    el.addEventListener("dragleave", () => {
+      // Keep indicator visible — let dragover on other tabs handle cleanup
+    });
+
+    el.addEventListener("drop", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (dragState.dragging === null) return;
+
+      const fromIndex = dragState.dragging;
+
+      // Determine target index
+      const rect = el.getBoundingClientRect();
+      const midX = rect.left + rect.width / 2;
+      const dropAfter = e.clientX > midX;
+      let toIndex = index;
+      if (dropAfter) toIndex++;
+
+      // Adjust for removing from array
+      if (fromIndex < toIndex) toIndex--;
+
+      moveTab(fromIndex, toIndex);
+
+      // Cleanup
+      tabBar.querySelectorAll(".tab-drop-indicator").forEach(el => el.remove());
+      dragState.dragging = null;
+      dragState.dropTarget = null;
     });
 
     el.append(led, title, close);

--- a/src/modules/ui/viewMode.js
+++ b/src/modules/ui/viewMode.js
@@ -1,49 +1,195 @@
 import { renderMarkdown } from "../markdown.js";
 
+const STORAGE_KEY = "snapdock:previewMode";
+
+/**
+ * Initialize the preview mode dropdown (replaces old toggle button).
+ *
+ * Supports three modes:
+ *   - "preview": full editor / full preview toggle (current behavior, active)
+ *   - "split":   side-by-side editor + preview (disabled, future)
+ *   - "live":    live preview auto-refresh (disabled, future)
+ *
+ * The selected mode is persisted to localStorage.
+ */
 export function initViewModeToggle({ toggleBtn, editor, preview }) {
   if (!toggleBtn || !editor || !preview) return;
 
   const editorWrapper = document.querySelector(".editor-wrapper");
   const previewWrapper = document.querySelector(".preview-wrapper");
+  const workspace = document.querySelector(".workspace");
+  const menu = document.getElementById("previewModeMenu");
+  const label = document.getElementById("previewModeLabel");
+  const container = document.getElementById("previewModeDropdown");
 
-  preview.classList.remove("hidden");
+  // --- Mode persistence ---
+  let currentMode = localStorage.getItem(STORAGE_KEY) || "preview";
+  if (!["preview", "split", "live"].includes(currentMode)) {
+    currentMode = "preview";
+  }
 
-  // Initial state: editor visible, preview hidden
-  previewWrapper.classList.add("hidden");
-  editorWrapper.classList.remove("hidden");
-  toggleBtn.textContent = "Show Preview";
+  // --- Update menu active state ---
+  function updateMenuActive() {
+    if (!menu) return;
+    menu.querySelectorAll(".preview-mode-option").forEach(opt => {
+      opt.classList.toggle("active", opt.dataset.mode === currentMode);
+    });
+  }
 
-  const updatePreview = () => {
+  // --- Update button label ---
+  function updateLabel() {
+    if (!label) return;
+    const modeLabels = {
+      preview: "Show Preview",
+      split: "Split View",
+      live: "Live View",
+    };
+    // If preview is currently showing, show "Edit Markdown"
+    const previewVisible = previewWrapper && !previewWrapper.classList.contains("hidden");
+    if (currentMode === "preview" && previewVisible) {
+      label.textContent = "Edit Markdown";
+    } else {
+      label.textContent = modeLabels[currentMode] || "Show Preview";
+    }
+  }
+
+  // --- Update preview content ---
+  const applyPreviewContent = () => {
     const html = renderMarkdown(editor.value);
     const parsed = new DOMParser().parseFromString(html, "text/html");
     preview.replaceChildren(...parsed.body.childNodes);
   };
 
-  // Update preview when switching tabs
-  document.addEventListener("snapdock:updatePreview", () => {
-    if (!previewWrapper.classList.contains("hidden")) {
-      updatePreview();
-    }
-  });
+  // --- Mode: Preview (full toggle) ---
+  function applyPreviewMode() {
+    if (!previewWrapper || !editorWrapper) return;
 
-  toggleBtn.addEventListener("click", () => {
     const showingPreview = !previewWrapper.classList.contains("hidden");
 
     if (showingPreview) {
+      // Switch to editor
       previewWrapper.classList.add("hidden");
       editorWrapper.classList.remove("hidden");
-      toggleBtn.textContent = "Show Preview";
     } else {
-      updatePreview();
+      // Switch to preview
+      applyPreviewContent();
       previewWrapper.classList.remove("hidden");
       editorWrapper.classList.add("hidden");
-      toggleBtn.textContent = "Edit Markdown";
+    }
+
+    // Remove split-view class from workspace
+    if (workspace) workspace.classList.remove("split-view");
+    updateLabel();
+  }
+
+  // --- Mode: Split View (disabled for now) ---
+  function applySplitMode() {
+    // Split View is not yet implemented — silently fall back to preview mode
+    currentMode = "preview";
+    localStorage.setItem(STORAGE_KEY, currentMode);
+    updateMenuActive();
+    applyPreviewMode();
+  }
+
+  // --- Mode: Live View (disabled for now) ---
+  function applyLiveMode() {
+    // Live View is not yet implemented — silently fall back to preview mode
+    currentMode = "preview";
+    localStorage.setItem(STORAGE_KEY, currentMode);
+    updateMenuActive();
+    applyPreviewMode();
+  }
+
+  // --- Dropdown menu toggle ---
+  const toggleMenu = () => {
+    if (!menu) return;
+    const isOpen = menu.classList.contains("open");
+    if (isOpen) {
+      menu.classList.remove("open");
+    } else {
+      menu.classList.add("open");
+    }
+  };
+
+  const closeMenu = () => {
+    if (menu) menu.classList.remove("open");
+  };
+
+  // --- Bind menu option clicks ---
+  if (menu) {
+    menu.querySelectorAll(".preview-mode-option").forEach(opt => {
+      opt.addEventListener("click", (e) => {
+        e.stopPropagation();
+        const mode = opt.dataset.mode;
+        if (opt.classList.contains("disabled")) return;
+
+        currentMode = mode;
+        localStorage.setItem(STORAGE_KEY, currentMode);
+        updateMenuActive();
+
+        if (mode === "preview") applyPreviewMode();
+        else if (mode === "split") applySplitMode();
+        else if (mode === "live") applyLiveMode();
+
+        closeMenu();
+      });
+    });
+  }
+
+  // --- Main button: toggle preview OR open dropdown ---
+  toggleBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    // If Shift+Click, open the dropdown menu
+    if (e.shiftKey) {
+      toggleMenu();
+      return;
+    }
+    // Regular click: apply current mode action
+    if (currentMode === "preview") {
+      applyPreviewMode();
+    } else if (currentMode === "split") {
+      applySplitMode();
+    } else if (currentMode === "live") {
+      applyLiveMode();
     }
   });
 
-  editor.addEventListener("input", () => {
-    if (!previewWrapper.classList.contains("hidden")) {
-      updatePreview();
+  // --- Open dropdown on right-click or dropdown arrow click ---
+  if (container) {
+    container.addEventListener("contextmenu", (e) => {
+      e.preventDefault();
+      toggleMenu();
+    });
+  }
+
+  // --- Close dropdown when clicking outside ---
+  document.addEventListener("click", (e) => {
+    if (container && !container.contains(e.target)) {
+      closeMenu();
     }
   });
+
+  // --- Update preview when switching tabs ---
+  document.addEventListener("snapdock:updatePreview", () => {
+    if (previewWrapper && !previewWrapper.classList.contains("hidden")) {
+      applyPreviewContent();
+    }
+  });
+
+  // --- Live preview while typing ---
+  editor.addEventListener("input", () => {
+    if (previewWrapper && !previewWrapper.classList.contains("hidden")) {
+      applyPreviewContent();
+    }
+  });
+
+  // --- Initialize ---
+  preview.classList.remove("hidden");
+  previewWrapper.classList.add("hidden");
+  editorWrapper.classList.remove("hidden");
+  updateMenuActive();
+  updateLabel();
+
+  // Expose for external use
+  return { getMode: () => currentMode };
 }

--- a/src/styles/components/tabs.css
+++ b/src/styles/components/tabs.css
@@ -118,3 +118,139 @@
   opacity: 1;
 }
 
+/* --- Drag & Drop --- */
+.tab.dragging {
+  opacity: 0.4;
+  transform: scale(0.95);
+}
+
+.tab-drop-indicator {
+  flex: 0 0 auto;
+  width: 3px;
+  height: 28px;
+  background: var(--tab-accent, #4a9eff);
+  border-radius: 2px;
+  margin: 0 2px;
+  align-self: flex-end;
+  animation: dropPulse 0.8s ease-in-out infinite alternate;
+}
+
+@keyframes dropPulse {
+  from { opacity: 0.6; }
+  to   { opacity: 1; }
+}
+
+/* --- Preview Mode Dropdown --- */
+.preview-mode-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.preview-mode-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 10px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  background: var(--btn-bg, #2a2a2a);
+  color: var(--btn-text, #ccc);
+  border: 1px solid var(--tab-border);
+  border-radius: 4px;
+  transition: all 0.15s ease;
+}
+
+.preview-mode-btn:hover {
+  background: var(--btn-hover-bg, #3a3a3a);
+}
+
+.preview-mode-btn .dropdown-arrow {
+  font-size: 0.6rem;
+  margin-left: 2px;
+}
+
+.preview-mode-menu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  right: 0;
+  min-width: 170px;
+  background: var(--dropdown-bg, #1e1e1e);
+  border: 1px solid var(--tab-border);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+  z-index: 100;
+  margin-top: 4px;
+  overflow: hidden;
+}
+
+.preview-mode-menu.open {
+  display: block;
+}
+
+.preview-mode-option {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 8px 12px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  color: var(--btn-text, #ccc);
+  text-align: left;
+  transition: background 0.1s ease;
+}
+
+.preview-mode-option:hover:not(.disabled) {
+  background: var(--btn-hover-bg, #3a3a3a);
+}
+
+.preview-mode-option.active {
+  color: var(--tab-accent, #4a9eff);
+  font-weight: 600;
+}
+
+.preview-mode-option.disabled {
+  color: #555;
+  cursor: not-allowed;
+}
+
+.preview-mode-option .option-check {
+  width: 16px;
+  margin-right: 8px;
+  font-size: 0.7rem;
+  visibility: hidden;
+}
+
+.preview-mode-option.active .option-check {
+  visibility: visible;
+}
+
+.preview-mode-option .option-label {
+  flex-grow: 1;
+}
+
+.preview-mode-option .option-badge {
+  font-size: 0.65rem;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: rgba(125,125,125,0.15);
+  color: #666;
+}
+
+/* --- Split View (future) --- */
+.workspace.split-view .editor-wrapper,
+.workspace.split-view .preview-wrapper {
+  width: 50%;
+  display: block !important;
+}
+
+.workspace.split-view .preview-wrapper.hidden {
+  display: none !important;
+}
+
+.workspace.split-view .workspace {
+  flex-direction: row;
+}
+


### PR DESCRIPTION
## What

Two UI enhancements for SnapDock V3:

### #84 — Tab Drag & Drop Reordering
- Tabs can now be reordered by dragging (native HTML5 drag & drop)
- Visual drop indicator with pulsing accent line shows insertion point
- Dragged tab fades to 40% opacity during drag
- Active tab stays active after reorder
- Compatible with unsaved indicators, close buttons, keyboard shortcuts

### #85 — Preview Mode Dropdown
- Replaces the single toggle button with a dropdown menu
- Three modes: Show Preview (active), Split View (disabled), Live View (disabled)
- Disabled items shown with gray text and 'soon' badge
- Selected mode persists via localStorage
- Menu accessible via: click (toggles preview), Shift+Click or right-click (opens dropdown)
- Future-proof: underlying logic structured so Split/Live View can be enabled without redesign

## Code Changes
- src/modules/file/tabs.js: Added moveTab(), drag event handlers, renderTabs() updated
- src/modules/ui/viewMode.js: Full rewrite with dropdown + mode persistence
- src/styles/components/tabs.css: Added drag/drop styles, dropdown menu styles, split view scaffolding
- index.html: Replaced button with dropdown container

Closes #84
Closes #85