### PR TITLE
feat: add Save All support for tabs and close confirmation

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
           <button id="openFolderBtnTop">Open Folder</button>
           <div class="divider"></div>
           <button id="saveFileBtnTop">Save</button>
+          <button id="saveAllBtnTop">Save All</button>
           <button id="exportPdfBtn">Export</button>
         </div>
 

--- a/main.js
+++ b/main.js
@@ -17,6 +17,7 @@ let workspaceWatcher = null;
 let currentWorkspacePath = null;
 let mainWindow;
 let lastKnownDirtyState = false;
+let forceClose = false;
 
 function createWindow() {
   mainWindow = new BrowserWindow({
@@ -47,6 +48,8 @@ function createWindow() {
 
   // Unsaved changes / workspace dirty failsafe
   mainWindow.on("close", (event) => {
+
+    if (forceClose) return;
     // Ask renderer for dirty state
     mainWindow.webContents.send("workspace:isDirty:request");
 
@@ -58,7 +61,7 @@ function createWindow() {
       if (lastKnownDirtyState) {
         const choice = dialog.showMessageBoxSync(mainWindow, {
           type: "warning",
-          buttons: ["Cancel", "Discard Changes"],
+          buttons: ["Cancel", "Save All", "Discard Changes"],
           defaultId: 0,
           cancelId: 0,
           title: "Unsaved Changes",
@@ -66,12 +69,38 @@ function createWindow() {
         });
 
         if (choice === 1) {
-          // User chose "Discard Changes"
-          mainWindow.destroy();
+          // User chose "Save All"
+          const onResult = (_event, result) => {
+            if (result?.ok) {
+              forceClose = true;
+              mainWindow.close();
+            } else {
+              dialog.showMessageBox(mainWindow, {
+                type: "error",
+                buttons: ["OK"],
+                defaultId: 0,
+                title: "Save All Failed",
+                message: "Some tabs could not be saved. SnapDock will remain open.",
+              });
+            }
+          };
+
+          ipcMain.once("workspace:save-all-for-close:result", onResult);
+          mainWindow.webContents.send("workspace:save-all-for-close:request");
+          return;
         }
+
+        if (choice === 2) {
+          // User chose "Discard Changes"
+          forceClose = true;
+          mainWindow.close();
+        }
+
+        // choice === 0 (Cancel): do nothing, keep app open
       } else {
-        // Clean workspace → safe to close
-        mainWindow.destroy();
+        // Clean workspace -> safe to close
+        forceClose = true;
+        mainWindow.close();
       }
     }, 50);
   });
@@ -79,191 +108,190 @@ function createWindow() {
   mainWindow.loadFile("index.html");
   setupUpdater(mainWindow);
 }
-
 app.whenReady().then(createWindow);
 
-// -----------------------------
-// FILE OPERATIONS
-// -----------------------------
+  // -----------------------------
+  // FILE OPERATIONS
+  // -----------------------------
 
-ipcMain.handle("open-file", async () => {
-  const { canceled, filePaths } = await dialog.showOpenDialog({
-    properties: ["openFile"],
-    filters: [{ name: "Markdown", extensions: ["md"] }],
-  });
-
-  if (canceled || filePaths.length === 0) return null;
-
-  const filePath = filePaths[0];
-  const content = fs.readFileSync(filePath, "utf-8");
-
-  return { content, filePath };
-});
-
-ipcMain.handle("open-folder", async () => {
-  const { canceled, filePaths } = await dialog.showOpenDialog({
-    properties: ["openDirectory"],
-  });
-
-  if (canceled || filePaths.length === 0) return null;
-  const workspacePath = filePaths[0];
-
-  // Close previous watcher if exists
-  if (workspaceWatcher) {
-    workspaceWatcher.close();
-  }
-  
-  currentWorkspacePath = workspacePath;
-  
-  workspaceWatcher = chokidar.watch(workspacePath, {
-    ignored: /(^|[\/\\])\../, // ignore dotfiles
-    persistent: true,
-  });
-  
-  let ready = false;
-  let refreshTimeout = null;
-  
-  workspaceWatcher
-    .on("ready", () => {
-      ready = true;
-    })
-    .on("all", () => {
-      if (!ready) return; // ignore initial scan events
-    
-      clearTimeout(refreshTimeout);
-      refreshTimeout = setTimeout(() => {
-        if (mainWindow) {
-          mainWindow.webContents.send("workspace-updated");
-        }
-      }, 100); // debounce to avoid double-refresh on Windows
+  ipcMain.handle("open-file", async () => {
+    const { canceled, filePaths } = await dialog.showOpenDialog({
+      properties: ["openFile"],
+      filters: [{ name: "Markdown", extensions: ["md"] }],
     });
-  
-  return workspacePath;
-});
 
-ipcMain.handle("save-file", async (event, filePath, content, suggestedName) => {
-  try {
-    if (!filePath) {
-      const { canceled, filePath: newFilePath } = await dialog.showSaveDialog({
-        title: "Save File",
-        defaultPath: suggestedName || "untitled",
-      });
+    if (canceled || filePaths.length === 0) return null;
 
-      if (canceled || !newFilePath) return false;
+    const filePath = filePaths[0];
+    const content = fs.readFileSync(filePath, "utf-8");
 
-      let finalPath = newFilePath;
+    return { content, filePath };
+  });
 
-      // If user didn't provide any extension, add .md
-      if (!path.extname(finalPath)) {
-        finalPath += ".md";
-      }
+  ipcMain.handle("open-folder", async () => {
+    const { canceled, filePaths } = await dialog.showOpenDialog({
+      properties: ["openDirectory"],
+    });
 
-      fs.writeFileSync(finalPath, content, "utf-8");
-      return { newFilePath: finalPath };
+    if (canceled || filePaths.length === 0) return null;
+    const workspacePath = filePaths[0];
+
+    // Close previous watcher if exists
+    if (workspaceWatcher) {
+      workspaceWatcher.close();
     }
 
-    fs.writeFileSync(filePath, content, "utf-8");
-    return true;
-  } catch (err) {
-    console.error("Failed to save file:", err);
-    return false;
-  }
-});
+    currentWorkspacePath = workspacePath;
 
-ipcMain.handle("open-recent-file", async (event, filePath) => {
-  try {
-    return fs.readFileSync(filePath, "utf-8");
-  } catch (err) {
-    console.error("Failed to open recent file:", err);
-    return null;
-  }
-});
+    workspaceWatcher = chokidar.watch(workspacePath, {
+      ignored: /(^|[\/\\])\../, // ignore dotfiles
+      persistent: true,
+    });
 
-ipcMain.handle("list-files", async (event, dirPath) => {
-  if (!dirPath || typeof dirPath !== "string") {
-    console.error("list-files called without valid path");
-    return [];
-  }
+    let ready = false;
+    let refreshTimeout = null;
 
-  try {
-    const files = fs.readdirSync(dirPath, { withFileTypes: true });
+    workspaceWatcher
+      .on("ready", () => {
+        ready = true;
+      })
+      .on("all", () => {
+        if (!ready) return; // ignore initial scan events
 
-    return files.map((f) => ({
-      name: f.name,
-      type: f.isDirectory() ? "folder" : "file",
-      fullPath: path.join(dirPath, f.name),
-    }));
-  } catch (err) {
-    console.error("Failed to list files:", err);
-    return [];
-  }
-});
+        clearTimeout(refreshTimeout);
+        refreshTimeout = setTimeout(() => {
+          if (mainWindow) {
+            mainWindow.webContents.send("workspace-updated");
+          }
+        }, 100); // debounce to avoid double-refresh on Windows
+      });
 
-ipcMain.handle("open-file-by-path", async (_, pathArg) => {
-  try {
-    return await fs.promises.readFile(pathArg, "utf8");
-  } catch {
-    return null;
-  }
-});
-
-ipcMain.handle("confirm-tab-close", async (event, title) => {
-  const choice = await dialog.showMessageBox({
-    type: "warning",
-    buttons: ["Cancel", "Discard Changes"],
-    defaultId: 0,
-    cancelId: 0,
-    title: "Unsaved Changes",
-    message: `"${title}" has unsaved changes. Close anyway?`,
+    return workspacePath;
   });
 
-  return choice.response === 1;
-});
+  ipcMain.handle("save-file", async (event, filePath, content, suggestedName) => {
+    try {
+      if (!filePath) {
+        const { canceled, filePath: newFilePath } = await dialog.showSaveDialog({
+          title: "Save File",
+          defaultPath: suggestedName || "untitled",
+        });
 
-// -----------------------------
-// HELP DOCUMENT
-// -----------------------------
+        if (canceled || !newFilePath) return false;
 
-ipcMain.handle("dialog:openHelp", async () => {
-  try {
-    const helpPath = path.join(
-      __dirname,
-      "assets",
-      "resources",
-      "docs",
-      "user_guide.md",
-    );
-    return fs.readFileSync(helpPath, "utf-8");
-  } catch (err) {
-    console.error("Failed to load help doc:", err);
-    return "# Help file not found";
-  }
-});
+        let finalPath = newFilePath;
 
-// -----------------------------
-// VERSION INFO
-// -----------------------------
+        // If user didn't provide any extension, add .md
+        if (!path.extname(finalPath)) {
+          finalPath += ".md";
+        }
 
-ipcMain.handle("get-version", async () => {
-  return {
-    version: pkg.version,
-    stage: pkg.buildStage,
-    date: pkg.releaseDate,
-  };
-});
+        fs.writeFileSync(finalPath, content, "utf-8");
+        return { newFilePath: finalPath };
+      }
 
-// -----------------------------
-// PDF EXPORT
-// -----------------------------
+      fs.writeFileSync(filePath, content, "utf-8");
+      return true;
+    } catch (err) {
+      console.error("Failed to save file:", err);
+      return false;
+    }
+  });
 
-ipcMain.handle("export-pdf", (event, htmlContent) => {
-  pdfModule.exportCurrentMarkdown(htmlContent);
-});
+  ipcMain.handle("open-recent-file", async (event, filePath) => {
+    try {
+      return fs.readFileSync(filePath, "utf-8");
+    } catch (err) {
+      console.error("Failed to open recent file:", err);
+      return null;
+    }
+  });
 
-// -----------------------------
-// WORKSPACE DIRTY STATE IPC
-// -----------------------------
+  ipcMain.handle("list-files", async (event, dirPath) => {
+    if (!dirPath || typeof dirPath !== "string") {
+      console.error("list-files called without valid path");
+      return [];
+    }
 
-ipcMain.on("workspace:isDirty:response", (event, isDirty) => {
-  lastKnownDirtyState = isDirty;
-});
+    try {
+      const files = fs.readdirSync(dirPath, { withFileTypes: true });
+
+      return files.map((f) => ({
+        name: f.name,
+        type: f.isDirectory() ? "folder" : "file",
+        fullPath: path.join(dirPath, f.name),
+      }));
+    } catch (err) {
+      console.error("Failed to list files:", err);
+      return [];
+    }
+  });
+
+  ipcMain.handle("open-file-by-path", async (_, pathArg) => {
+    try {
+      return await fs.promises.readFile(pathArg, "utf8");
+    } catch {
+      return null;
+    }
+  });
+
+  ipcMain.handle("confirm-tab-close", async (event, title) => {
+    const choice = await dialog.showMessageBox({
+      type: "warning",
+      buttons: ["Cancel", "Discard Changes"],
+      defaultId: 0,
+      cancelId: 0,
+      title: "Unsaved Changes",
+      message: `"${title}" has unsaved changes. Close anyway?`,
+    });
+
+    return choice.response === 1;
+  });
+
+  // -----------------------------
+  // HELP DOCUMENT
+  // -----------------------------
+
+  ipcMain.handle("dialog:openHelp", async () => {
+    try {
+      const helpPath = path.join(
+        __dirname,
+        "assets",
+        "resources",
+        "docs",
+        "user_guide.md",
+      );
+      return fs.readFileSync(helpPath, "utf-8");
+    } catch (err) {
+      console.error("Failed to load help doc:", err);
+      return "# Help file not found";
+    }
+  });
+
+  // -----------------------------
+  // VERSION INFO
+  // -----------------------------
+
+  ipcMain.handle("get-version", async () => {
+    return {
+      version: pkg.version,
+      stage: pkg.buildStage,
+      date: pkg.releaseDate,
+    };
+  });
+
+  // -----------------------------
+  // PDF EXPORT
+  // -----------------------------
+
+  ipcMain.handle("export-pdf", (event, htmlContent) => {
+    pdfModule.exportCurrentMarkdown(htmlContent);
+  });
+
+  // -----------------------------
+  // WORKSPACE DIRTY STATE IPC
+  // -----------------------------
+
+  ipcMain.on("workspace:isDirty:response", (event, isDirty) => {
+    lastKnownDirtyState = isDirty;
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -399,6 +399,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -420,6 +421,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -436,6 +438,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -450,6 +453,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1218,7 +1222,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
@@ -1235,7 +1240,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -1338,7 +1344,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2076,7 +2081,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2370,7 +2376,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -2583,6 +2588,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -2603,6 +2609,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -3752,7 +3759,6 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -4073,6 +4079,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -4367,7 +4374,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4397,6 +4403,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -4414,6 +4421,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -4641,6 +4649,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -5030,6 +5039,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"

--- a/src/modules/file/tabs.js
+++ b/src/modules/file/tabs.js
@@ -1,4 +1,5 @@
 // src/modules/file/tabs.js
+import { saveCurrentFile } from "./operations.js";
 
 let tabs = [];
 let activeTabId = null;
@@ -300,4 +301,29 @@ export function markDirty() {
   renderTabs();
 }
 
+export async function save_all_tabs(){
+  const dirtyTabs = tabs.filter(tab => tab.isDirty);
+  if(!dirtyTabs.length){
+    return {savedCount:0,failedCount:0,failedTabs:[]};
+  }
+
+
+  let savedCount = 0;
+  const failedTabs = [];
+
+  for(const tab of dirtyTabs){
+    const ok = await saveCurrentFile(tab);
+    if(ok) {
+      savedCount++;
+    } else {
+      failedTabs.push(tab.title);
+    }
+  }
+
+  return {
+    savedCount,
+    failedCount: failedTabs.length,
+    failedTabs
+  };
+}
 export { tabs };

--- a/src/modules/ui/editorSync.js
+++ b/src/modules/ui/editorSync.js
@@ -5,7 +5,8 @@ import {
   getActiveTab,
   switchToTab,
   markDirty,
-  renderTabs
+  renderTabs,
+  save_all_tabs
 } from "../file/tabs.js";
 
 import { saveCurrentFile } from "../file/operations.js";
@@ -36,5 +37,15 @@ export function initEditorSync() {
     if (!tab) return;
 
     await saveCurrentFile(tab);
+  });
+
+  // save all dirty tabs
+  document.getElementById('saveAllBtnTop')?.addEventListener('click', async() => {
+    const tab = getActiveTab();
+    if(tab && editor){
+      // capture latest in-editor text before batch save
+      tab.content = editor.value;
+    }
+    await save_all_tabs();
   });
 }

--- a/src/preload.js
+++ b/src/preload.js
@@ -76,4 +76,10 @@ contextBridge.exposeInMainWorld("workspaceAPI", {
 
   sendDirtyState: (isDirty) =>
     ipcRenderer.send("workspace:isDirty:response", isDirty),
+    
+  onSaveAllForCloseRequest: (callback) =>
+    ipcRenderer.on("workspace:save-all-for-close:request", () => callback()),
+
+  sendSaveAllForCloseResult: (result) =>
+    ipcRenderer.send("workspace:save-all-for-close:result", result),
 });

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -8,7 +8,7 @@ import { initResizer } from "./modules/ui/resizer.js";
 import { initUpdateSystem } from "./modules/system/update.js";
 import { openFileDialog, openFromRecent } from "./modules/file/open.js";
 import { respondToDirtyStateRequest } from "./modules/system/dirtyState.js";
-
+import { save_all_tabs } from "./modules/file/tabs.js"
 
 // Helper
 function byId(id) {
@@ -17,6 +17,25 @@ function byId(id) {
 
 // Dirty State Request Listener
 window.workspaceAPI.onDirtyStateRequest(respondToDirtyStateRequest);
+
+// close-flow save all request frm main process
+window.workspaceAPI.onSaveAllForCloseRequest(async() => {
+  try{
+    const result = await save_all_tabs();
+    window.workspaceAPI.sendSaveAllForCloseResult({
+      ok:result.failedCount === 0,
+      ...result
+    })
+  }catch(err){
+    window.workspaceAPI.sendSaveAllForCloseResult({
+      ok:false,
+      savedCount:0,
+      failedCount:1,
+      failedTabs:[],
+      error: err.message || String(err)
+    });
+  }
+})
 
 // --- MAIN BOOTSTRAP ---
 window.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Save All (UX Improvement)

Closes #82

SnapDock now supports **Save All** for multi-tab workflows.

### What was added

#### Toolbar action
- Added a **Save All** button next to **Save**
- Saves all open tabs with unsaved changes
- Skips clean tabs automatically
- Updates tab save-state indicators after save

#### Close dialog action
The unsaved-changes prompt now includes:

- `Cancel`
- `Save All`
- `Discard Changes`

**Save All behavior**
- Saves all dirty tabs before closing SnapDock
- No per-tab discard prompts in this flow
- App closes only after successful saves

### Core implementation

- Added `save_all_tabs()` in `src/modules/file/tabs.js`
- Wired toolbar action in `src/modules/ui/editorSync.js`
- Added close-flow IPC bridge:

#### `src/preload.js`
- `workspaceAPI.onSaveAllForCloseRequest(...)`
- `workspaceAPI.sendSaveAllForCloseResult(...)`

#### `src/scripts.js`
- Handles close-time save-all request
- Executes `save_all_tabs()`
- Returns result to main process

#### `main.js`
- Updated close orchestration to support **Save All** decision flow

### Notes / Current Limitations

- Untitled dirty tabs may open **Save As** dialogs (expected behavior)
- Batch save is **best-effort** (no transactional rollback)
- Manual feature only (**no autosave yet**)

### Manual Testing

- [x] Tested toolbar **Save All** with multiple dirty tabs
- [x] Verified clean tabs are skipped
- [x] Verified save-state indicators update correctly
- [x] Tested close dialog **Save All** flow
- [x] Verified app closes after successful save
- [x] Tested in single-file and folder workspace modes