### PR TITLE
feat: added emoji support

### DIFF
--- a/src/modules/markdown.js
+++ b/src/modules/markdown.js
@@ -8,6 +8,7 @@ import sub from "markdown-it-sub";
 import sup from "markdown-it-sup";
 import container from "markdown-it-container";
 import hljs from "highlight.js";
+import { full as emoji } from "markdown-it-emoji";
 
 // MarkdownIt Instance
 
@@ -32,6 +33,7 @@ md.use(taskLists, { enabled: true });
 md.use(mark);
 md.use(sub);
 md.use(sup);
+md.use(emoji);
 
 md.use(anchor, {
   level: [1, 2, 3, 4]


### PR DESCRIPTION
# Pull Request

Thank you for contributing to SnapDock!  
Please complete the sections below to help us review your PR.

---

## Summary

This PR enables emoji shortcode rendering in SnapDock’s Markdown preview by wiring the `markdown-it-emoji` plugin into the renderer pipeline. Emoji shortcodes such as `:smile:` and `:rocket:` now correctly expand to Unicode emoji.

---

## Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] UI/UX improvement  
- [ ] Documentation update  
- [ ] Refactor / cleanup  

---

## Details

- Added the `markdown-it-emoji` plugin to the MarkdownIt pipeline.  
- Updated the import to use the `full` emoji set due to changes in the plugin’s export structure.  
- No other renderer components were modified.  
- This restores expected emoji rendering without affecting containers, syntax highlighting, or link attributes.

---

## Testing

- [x] Builds successfully  
- [x] Tested on Windows  
- [ ] Tested on Linux  
- [x] No regressions found  

Testing included:

- Rendering common emoji shortcodes (`:smile:`, `:rocket:`, `:+1:`).  
- Verifying emoji inside containers and inline text.  
- Confirming no conflicts with highlight.js or other markdown-it plugins.

---

## Related Issues

Fixes **#134**  
Related to **#132**

---

## Additional Notes (optional)

This was a small wiring fix with no UI changes. Emoji customization (themes, fallback glyphs, etc.) can be added later if needed.

---
