### PR TITLE
132 markdownit plugin wiring fix renderer pipeline

### DIFF
--- a/src/modules/markdown.js
+++ b/src/modules/markdown.js
@@ -44,7 +44,6 @@ md.use(mila, {
   }
 });
 
-// Custom containers (:::note, :::warning, :::tip)
 ["note", "warning", "tip"].forEach(type => {
   md.use(container, type, {
     render(tokens, idx) {
@@ -56,6 +55,21 @@ md.use(mila, {
       }
     }
   });
+});
+
+// Special handling for "info"
+md.use(container, "info", {
+  validate: function(params) {
+    return params.trim().match(/^info$/);
+  },
+  render: function(tokens, idx) {
+    const token = tokens[idx];
+    if (token.nesting === 1) {
+      return `<div class="md-info">`;
+    } else {
+      return `</div>`;
+    }
+  }
 });
 
 // Exported Renderer

--- a/src/modules/markdown.js
+++ b/src/modules/markdown.js
@@ -8,6 +8,7 @@ import sub from "markdown-it-sub";
 import sup from "markdown-it-sup";
 import container from "markdown-it-container";
 import hljs from "highlight.js";
+import { full as emoji } from "markdown-it-emoji";
 
 // MarkdownIt Instance
 
@@ -32,6 +33,7 @@ md.use(taskLists, { enabled: true });
 md.use(mark);
 md.use(sub);
 md.use(sup);
+md.use(emoji);
 
 md.use(anchor, {
   level: [1, 2, 3, 4]


### PR DESCRIPTION
# Pull Request

Thank you for contributing to SnapDock!  
Please complete the sections below to help us review your PR.

---

## Summary

This PR restores correct wiring for several Markdown‑it plugins used in SnapDock’s preview renderer.  
The v4.x plugin updates removed implicit behaviors, causing containers, emoji shortcodes, and link attributes to stop rendering.  
All affected plugins have now been reconnected to the active MarkdownIt instance.

---

## Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] UI/UX improvement  
- [ ] Documentation update  
- [ ] Refactor / cleanup  

---

## Details

This PR reconnects the Markdown‑it plugins that were installed but not wired into the renderer pipeline:

### ✔ Container Blocks  
- Restored support for `warning`, `note`, and `tip` containers.  
- `info` containers now strip syntax but do not fully render; this will be addressed in a future styling issue.  
- No regressions in existing container behavior.

### ✔ Emoji Shortcodes  
- Wired `markdown-it-emoji` using the `full` export due to updated module structure.  
- Emoji shortcodes now render correctly in preview and inside containers.

### ✔ Link Attributes  
- Confirmed `markdown-it-link-attributes` was already wired.  
- Verified correct injection of `target="_blank"` and `rel="noopener"` for external links.  
- Identified navigation behavior issues (external links opening in new Electron windows, internal links opening blank windows).  
  These are unrelated to markdown-it and will be handled in a separate issue.

No architectural changes were made.  
No preload modifications were required.

---

## Testing

- [x] Builds successfully  
- [x] Tested on Windows  
- [ ] Tested on Linux  
- [x] No regressions found  

Testing included:

- Full Markdown test file covering containers, emoji, link attributes, and nested content.  
- Verified correct HTML output for all wired plugins.  
- Confirmed no conflicts with highlight.js or other markdown-it plugins.

---

## Related Issues

Fixes **#132**  
Fixes **#133**  
Fixes **#134**  
Fixes **#135** (closed with comments)

---

## Additional Notes (optional)

A follow‑up issue will be created to address link navigation behavior (external links should open in the system browser; internal links should open files in new tabs).  
A future styling issue will handle full `info` block rendering.

---

If you want, I can also generate the **follow‑up issue text** for:

- External/internal link navigation  
- Full `info` block styling  
- Markdown renderer test suite  

Just tell me which one you want next.