### PR TITLE
FEAT: unlocked right click | version bump for milestone

### DIFF
--- a/main.js
+++ b/main.js
@@ -53,6 +53,7 @@ function createWindow() {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: false,
+      spellcheck: true, // enables right click window
     },
     // Use a frameless window so we can render a custom SnapDock titlebar
     frame: false,
@@ -73,6 +74,26 @@ function createWindow() {
     ) {
       event.preventDefault();
     }
+  });
+  // NEW: right click window
+  const { Menu } = require("electron");
+
+  mainWindow.webContents.on("context-menu", (_event, params) => {
+    // Only show menu for editable elements (textarea, input)
+    if (!params.isEditable) return;
+
+    const menu = Menu.buildFromTemplate([
+      { role: "undo" },
+      { role: "redo" },
+      { type: "separator" },
+      { role: "cut" },
+      { role: "copy" },
+      { role: "paste" },
+      { type: "separator" },
+      { role: "selectAll" },
+    ]);
+
+    menu.popup({ window: mainWindow });
   });
 
   // Unsaved changes / workspace dirty failsafe

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapdock",
-  "version": "3.1.2",
+  "version": "3.2.2",
   "description": "A Minimal, Modern Markdown Editor",
   "synopsis": "Fast, clean Markdown editor",
   "homepage": "https://snapdock.app",


### PR DESCRIPTION
# Pull Request

Thank you for contributing to SnapDock!  
Please complete the sections below to help us review your PR.

---

## Summary

This PR restores the native right‑click context menu inside the SnapDock editor.  
Users can now access standard OS/browser editing actions such as copy, paste, undo, redo, and select‑all.  
This improves basic editing usability and aligns SnapDock with expected editor behavior.

---

## Type of Change

- [ ] Bug fix  
- [x] New feature  
- [x] UI/UX improvement  
- [ ] Documentation update  
- [ ] Refactor / cleanup  

---

## Details

Electron does not provide a default context menu.  
SnapDock previously suppressed right‑click behavior during earlier versions to prevent DevTools access, which unintentionally removed native editing actions.

This PR adds a `context-menu` listener in the main process and displays a standard editing menu when the user right‑clicks inside an editable element.  
The implementation is minimal and does not modify renderer logic or security settings.

Spellcheck support is not included in this PR and may be addressed in a future milestone.

---

## Testing

- [x] Builds successfully  
- [x] Tested on Windows  
- [ ] Tested on Linux  
- [x] No regressions found  

Testing notes:

- Verified right‑click menu appears inside the editor  
- Verified menu does not appear on non‑editable UI elements  
- Confirmed undo/redo/copy/paste/select‑all actions work as expected  
- Confirmed no interference with existing keyboard shortcuts or editor behavior  

---

## Related Issues

`Fixes #150`

---

## Additional Notes (optional)

This change restores expected editor functionality with minimal code impact.  
Spellcheck and extended writing tools may be added in a later milestone.

---