### PR TITLE
149 editor status bar metrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,9 @@
       </div>
 
       <footer class="footer">
-        <div class="footer-left"></div>
+        <div class="footer-left">
+          <span id="metricStats" class="metrics"></span>
+        </div>
         <div class="footer-center">
           <span id="versionTag" class="version"></span>
         </div>

--- a/src/modules/file/tabs.js
+++ b/src/modules/file/tabs.js
@@ -1,5 +1,6 @@
 // src/modules/file/tabs.js
 import { saveCurrentFile } from "./operations.js";
+import { updateMetrics } from "../ui/metrics.js";
 
 let tabs = [];
 let activeTabId = null;
@@ -104,6 +105,8 @@ export function switchToTab(tabId) {
   if (!next || !editor) return;
 
   editor.value = next.content;
+  // update metrics call
+  updateMetrics();
 
   const filenameEl = document.getElementById("filenameDisplay");
   if (filenameEl) filenameEl.textContent = next.title;

--- a/src/modules/ui/metrics.js
+++ b/src/modules/ui/metrics.js
@@ -1,0 +1,35 @@
+// src/modules/ui/metrics.js
+
+let editorRef = null;
+let elRef = null;
+
+export function initMetrics(editor) {
+  editorRef = editor;
+  elRef = document.getElementById("metricStats");
+
+  if (!editorRef || !elRef) return;
+
+  // Attach listeners
+  editorRef.addEventListener("input", updateMetrics);
+  editorRef.addEventListener("click", updateMetrics);
+  editorRef.addEventListener("keyup", updateMetrics);
+
+  updateMetrics(); // initial render
+}
+
+export function updateMetrics() {
+  if (!editorRef || !elRef) return;
+
+  const value = editorRef.value;
+
+  const totalChars = value.length;
+  const totalWords = value.trim().split(/\s+/).filter(Boolean).length;
+
+  const cursorPos = editorRef.selectionStart;
+  const textBeforeCursor = value.slice(0, cursorPos);
+
+  const line = textBeforeCursor.split("\n").length;
+  const column = cursorPos - textBeforeCursor.lastIndexOf("\n");
+
+  elRef.textContent = `Ln ${line}, Col ${column} • ${totalWords} words • ${totalChars} chars`;
+}

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -8,6 +8,7 @@ import { openFileDialog } from "./modules/file/open.js";
 import { respondToDirtyStateRequest } from "./modules/system/dirtyState.js";
 import { save_all_tabs } from "./modules/file/tabs.js";
 import { initDropdownToggles, initToolsDropdown } from "./modules/ui/dropdownMenus.js";
+import { initMetrics } from "./modules/ui/metrics.js";
 
 // Helper
 function byId(id) {
@@ -56,5 +57,9 @@ window.addEventListener("DOMContentLoaded", () => {
 
   // File Open Button (inside the Open dropdown — same ID)
   byId("openFileBtnTop")?.addEventListener("click", openFileDialog);
+
+  // metrics for footer
+  const editor = document.getElementById("markdownInputMain");
+  initMetrics(editor);
 
 });

--- a/src/styles/components/footer.css
+++ b/src/styles/components/footer.css
@@ -17,17 +17,27 @@
   align-items: center;
   padding: 0 12px;
   z-index: 9999; /* Ensure it stays above the scrolling workspace */
+  position: relative;
 }
 
 .footer-left,
-.footer-center,
 .footer-right {
   display: flex;
   align-items: center;
   gap: 12px;
 }
 
+.footer-center {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
 /* Version & Status Text */
+.metrics,
 .version {
   opacity: 0.6;
   font-family: var(--font-mono); /* Monospace looks great in status bars */


### PR DESCRIPTION
# Pull Request

Thank you for contributing to SnapDock!  
Please complete the sections below to help us review your PR.

---

## Summary

This PR adds basic editor metrics to the SnapDock footer.  
The status bar now displays line number, column number, total word count, and total character count for the active editor tab.

---

## Type of Change

- [ ] Bug fix  
- [x] New feature  
- [x] UI/UX improvement  
- [ ] Documentation update  
- [ ] Refactor / cleanup  

---

## Details

A new `metrics.js` module was introduced under `src/modules/ui/`.  
It provides two functions:

- `initMetrics(editor)` — attaches listeners and initializes the metrics display  
- `updateMetrics()` — updates the footer metrics based on the current editor content and cursor position

The footer layout was updated to include a new `<span id="metricStats">` element.  
Metrics refresh automatically on input, cursor movement, and tab switching.

The implementation is intentionally minimal to avoid scope creep and fits within the existing UI structure.

---

## Testing

- [x] Builds successfully  
- [x] Tested on Windows  
- [ ] Tested on Linux  
- [x] No regressions found  

Testing notes:

- Verified metrics update while typing  
- Verified metrics update when switching tabs  
- Verified metrics update when clicking within the editor  
- Verified footer layout remains stable and centered  

---

## Related Issues

`Fixes #149`

---

## Additional Notes (optional)

---