### PR TITLE
fix: prevent page overflow beneath footer

### DIFF
--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -1,8 +1,9 @@
 const esbuild = require("esbuild");
+const path = require("path");
 
 esbuild.build({
-  entryPoints: ["src/scripts.js"],
+  entryPoints: [path.join(__dirname, "..", "src", "scripts.js")],
   bundle: true,
-  outfile: "dist/bundle.js",
+  outfile: path.join(__dirname, "..", "dist", "bundle.js"),
   platform: "browser",
 }).catch(() => process.exit(1));

--- a/src/styles/components/workarea.css
+++ b/src/styles/components/workarea.css
@@ -14,7 +14,9 @@
   position: relative;
   width: 80%;
   max-width: 900px;
-  height: calc(100vh - 120px);
+  /* Size against the flex-managed app container so the footer and header are
+     always accounted for, regardless of window size or toolbar height. */
+  height: 100%;
   background: var(--editor-bg);
   color: var(--editor-text);
   display: flex;


### PR DESCRIPTION
## Summary

- Size the editor bubble from the flex-managed app container so the footer and header are included in the available viewport.
- Resolve renderer bundle entry and output paths relative to the build script.

## Root cause

The editor bubble used a viewport-based height that could exceed the available workspace after the header, tab bar, and footer were laid out. This clipped the bottom of long documents.

## Validation

- Validated manually on Windows
- `npm run build:dev`
