### PR TITLE
fix: resolve relative image attachments

### DIFF
--- a/src/modules/markdown.js
+++ b/src/modules/markdown.js
@@ -46,6 +46,23 @@ md.use(mila, {
   }
 });
 
+const defaultImageRenderer = md.renderer.rules.image;
+
+md.renderer.rules.image = (tokens, index, options, env, self) => {
+  const token = tokens[index];
+  const source = token.attrGet("src");
+  const documentPath = env?.documentPath;
+
+  if (source && documentPath && window.electronAPI?.resolveLocalAttachment) {
+    token.attrSet(
+      "src",
+      window.electronAPI.resolveLocalAttachment(documentPath, source)
+    );
+  }
+
+  return defaultImageRenderer(tokens, index, options, env, self);
+};
+
 ["note", "warning", "tip"].forEach(type => {
   md.use(container, type, {
     render(tokens, idx) {
@@ -76,6 +93,6 @@ md.use(container, "info", {
 
 // Exported Renderer
 
-export function renderMarkdown(text) {
-  return md.render(text || "");
+export function renderMarkdown(text, env = {}) {
+  return md.render(text || "", env);
 }

--- a/src/modules/ui/viewMode.js
+++ b/src/modules/ui/viewMode.js
@@ -1,4 +1,5 @@
 import { renderMarkdown } from "../markdown.js";
+import { getActiveTab } from "../file/tabs.js";
 
 const STORAGE_KEY = "snapdock:previewMode";
 
@@ -71,7 +72,9 @@ export function initViewModeToggle({ toggleBtn, editor, preview }) {
 
   // --- Update preview content ---
   const applyPreviewContent = () => {
-    const html = renderMarkdown(editor.value);
+    const html = renderMarkdown(editor.value, {
+      documentPath: getActiveTab()?.filePath,
+    });
     const parsed = new DOMParser().parseFromString(html, "text/html");
     preview.replaceChildren(...parsed.body.childNodes);
   };

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,6 +1,22 @@
 const { contextBridge, ipcRenderer } = require("electron");
+const path = require("path");
+const { pathToFileURL } = require("url");
 const MarkdownIt = require("markdown-it");
 const md = new MarkdownIt();
+
+function resolveLocalAttachment(documentPath, attachmentPath) {
+  if (!documentPath || !attachmentPath) return attachmentPath;
+
+  const isRelativePath =
+    !path.isAbsolute(attachmentPath) &&
+    !/^(?:[a-z][a-z\d+.-]*:|\/\/|[\\/])/i.test(attachmentPath);
+
+  if (!isRelativePath) return attachmentPath;
+
+  return pathToFileURL(
+    path.resolve(path.dirname(documentPath), attachmentPath)
+  ).href;
+}
 
 // -----------------------------
 // Markdown renderer
@@ -24,6 +40,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke("confirm-tab-close", title),
   openFileByPath: (path) =>
     ipcRenderer.invoke("open-file-by-path", path),
+  resolveLocalAttachment,
 
   // Workspace watcher
   onWorkspaceUpdated: (callback) =>


### PR DESCRIPTION
## Summary

- Resolve relative Markdown image paths against the active document folder.
- Render resolved paths as `file://` URLs so they work in preview and PDF export.
- Leave external, absolute, root-relative, and anchor URLs unchanged.

## Root cause

The renderer had no active-document path context, so relative image sources were interpreted relative to the application rather than the Markdown file. PDF export reused that unresolved HTML.

## Validation

- Manually validated on Windows
- `npm run build:dev`
