### PR TITLE
fix: removed annoying text

### DIFF
--- a/src/modules/ui/editorState.js
+++ b/src/modules/ui/editorState.js
@@ -2,7 +2,7 @@ export function initInitialState({ editor }) {
   if (!editor) return;
 
   if (!editor.value.trim()) {
-    editor.value = "# SnapDock Start typing...";
+    editor.value = "";
   }
 
   editor.focus();


### PR DESCRIPTION
# Pull Request

Thank you for contributing to SnapDock!  
Please complete the sections below to help us review your PR.

---

## Summary

Describe what this PR changes and why.

Nice and easy one today, all i did was remove the hard text `# SnapDock Start typing...` this shows up when ever snapdock is opened and needs to be deleted before work can start normally 

---

## Type of Change

- [ ] Bug fix  
- [ ] New feature  
- [X] UI/UX improvement  
- [ ] Documentation update  
- [ ] Refactor / cleanup  

---

## Details

Explain the implementation, any decisions made, and any side effects.

simply removed `# SnapDock Start typing...` while i could of made more edits this was the quickest and cleanest to get the outcome

---

## Testing

Describe how you tested your changes:

- [x] Builds successfully  
- [x] Tested on Windows  
- [x] Tested on Linux  
- [x] No regressions found  

---

## Related Issues

Link any related issues or discussions:

`Fixes #123` or `Related to #456`

no issue was raised for this

---

## Additional Notes (optional)

Anything else reviewers should know.
