### PR TITLE
fix: linking issue | added test

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,9 +1,10 @@
-const { app, BrowserWindow, dialog, ipcMain } = require("electron");
+const { app, BrowserWindow, dialog, ipcMain, shell } = require("electron");
 const chokidar = require("chokidar");
 const fs = require("fs");
 const path = require("path");
 const pkg = require("./package.json");
 const pdfModule = require("./src/modules/pdf/pdf.js");
+const { isExternalLink } = require("./src/modules/linkNavigation.js");
 
 /* Metadata loading with fallback:
 - During development, we read directly from package.json for simplicity.
@@ -72,6 +73,25 @@ function createWindow() {
 
   mainWindow.webContents.setZoomFactor(zoom);
   // ------------------------
+
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (isExternalLink(url)) {
+      shell.openExternal(url);
+      return { action: "deny" };
+    }
+
+    return { action: "deny" };
+  });
+
+  mainWindow.webContents.on("will-navigate", (event, url) => {
+    if (isExternalLink(url)) {
+      event.preventDefault();
+      shell.openExternal(url);
+      return;
+    }
+
+    event.preventDefault();
+  });
 
   // Remove all menus
   mainWindow.setMenu(null);
@@ -305,6 +325,12 @@ app.whenReady().then(createWindow);
     } catch {
       return null;
     }
+  });
+
+  ipcMain.handle("open-external-link", async (_, target) => {
+    if (!target || !isExternalLink(target)) return false;
+    shell.openExternal(target);
+    return true;
   });
 
   ipcMain.handle("confirm-tab-close", async (event, title) => {

--- a/src/modules/linkNavigation.js
+++ b/src/modules/linkNavigation.js
@@ -1,0 +1,50 @@
+const path = require("path");
+const { fileURLToPath } = require("url");
+
+function isExternalLink(target) {
+  if (!target || typeof target !== "string") return false;
+
+  const trimmed = target.trim();
+  if (!trimmed) return false;
+
+  if (trimmed.startsWith("#")) return false;
+
+  if (trimmed.startsWith("file:")) return false;
+
+  const protocolPattern = /^(?:[a-z][a-z\d+.-]*:|\/\/)/i;
+  if (protocolPattern.test(trimmed)) return true;
+
+  return false;
+}
+
+function resolveLocalPath(documentPath, target) {
+  if (!documentPath || !target || typeof target !== "string") return null;
+
+  const trimmed = target.trim();
+  if (!trimmed || trimmed.startsWith("#") || isExternalLink(trimmed)) {
+    return null;
+  }
+
+  const withoutFragment = trimmed.split("#")[0].split("?")[0];
+  if (!withoutFragment) return null;
+
+  if (trimmed.startsWith("file:")) {
+    try {
+      return fileURLToPath(trimmed);
+    } catch {
+      return null;
+    }
+  }
+
+  if (path.isAbsolute(withoutFragment)) {
+    return withoutFragment;
+  }
+
+  const dir = path.dirname(documentPath);
+  return path.resolve(dir, withoutFragment);
+}
+
+module.exports = {
+  isExternalLink,
+  resolveLocalPath,
+};

--- a/src/modules/ui/viewMode.js
+++ b/src/modules/ui/viewMode.js
@@ -1,5 +1,6 @@
 import { renderMarkdown } from "../markdown.js";
 import { getActiveTab } from "../file/tabs.js";
+import { handleFileOpen } from "../file/open.js";
 
 const STORAGE_KEY = "snapdock:previewMode";
 
@@ -77,6 +78,31 @@ export function initViewModeToggle({ toggleBtn, editor, preview }) {
     });
     const parsed = new DOMParser().parseFromString(html, "text/html");
     preview.replaceChildren(...parsed.body.childNodes);
+  };
+
+  const handlePreviewLinkClick = async (event) => {
+    const anchor = event.target.closest("a");
+    if (!anchor) return;
+
+    const href = anchor.getAttribute("href");
+    if (!href) return;
+
+    if (window.electronAPI?.isExternalLink?.(href)) {
+      event.preventDefault();
+      event.stopPropagation();
+      await window.electronAPI.openExternalLink(href);
+      return;
+    }
+
+    const documentPath = getActiveTab()?.filePath;
+    const resolvedPath = window.electronAPI?.resolveLocalPath?.(documentPath, href);
+    if (!resolvedPath) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const fileName = resolvedPath.split(/[\\/]/).pop();
+    await handleFileOpen(resolvedPath, fileName);
   };
 
   // --- Mode: Preview (full toggle) ---
@@ -258,6 +284,8 @@ export function initViewModeToggle({ toggleBtn, editor, preview }) {
       applyPreviewContent();
     }
   });
+
+  preview.addEventListener("click", handlePreviewLinkClick);
 
   // --- Live preview while typing ---
   editor.addEventListener("input", () => {

--- a/src/preload.js
+++ b/src/preload.js
@@ -2,6 +2,7 @@ const { contextBridge, ipcRenderer } = require("electron");
 const path = require("path");
 const { pathToFileURL } = require("url");
 const MarkdownIt = require("markdown-it");
+const { isExternalLink, resolveLocalPath } = require("./modules/linkNavigation.js");
 const md = new MarkdownIt();
 
 function resolveLocalAttachment(documentPath, attachmentPath) {
@@ -40,6 +41,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke("confirm-tab-close", title),
   openFileByPath: (path) =>
     ipcRenderer.invoke("open-file-by-path", path),
+  openExternalLink: (target) =>
+    ipcRenderer.invoke("open-external-link", target),
+  isExternalLink,
+  resolveLocalPath,
   resolveLocalAttachment,
 
   // Workspace watcher

--- a/tests/link-navigation.test.js
+++ b/tests/link-navigation.test.js
@@ -1,0 +1,36 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { isExternalLink, resolveLocalPath } = require("../src/modules/linkNavigation.js");
+
+test("classifies external URLs correctly", () => {
+  assert.equal(isExternalLink("https://google.com"), true);
+  assert.equal(isExternalLink("http://example.com"), true);
+  assert.equal(isExternalLink("mailto:test@example.com"), true);
+  assert.equal(isExternalLink("tel:+123456"), true);
+  assert.equal(isExternalLink("./README.md"), false);
+  assert.equal(isExternalLink("README.md"), false);
+  assert.equal(isExternalLink("#section"), false);
+});
+
+test("resolves relative links against the current document directory", () => {
+  assert.equal(
+    resolveLocalPath("/home/user/project/docs/guide.md", "./README.md"),
+    "/home/user/project/docs/README.md"
+  );
+  assert.equal(
+    resolveLocalPath("/home/user/project/docs/guide.md", "../README.md"),
+    "/home/user/project/README.md"
+  );
+});
+
+test("strips anchors and queries before resolving a local path", () => {
+  assert.equal(
+    resolveLocalPath("/home/user/project/docs/guide.md", "./README.md#section"),
+    "/home/user/project/docs/README.md"
+  );
+  assert.equal(
+    resolveLocalPath("/home/user/project/docs/guide.md", "./README.md?view=full"),
+    "/home/user/project/docs/README.md"
+  );
+});


### PR DESCRIPTION
# Pull Request

Thank you for contributing to SnapDock!  
Please complete the sections below to help us review your PR.

---

## Summary

This PR fixes link navigation behavior in the Markdown preview so SnapDock no longer opens blank Electron windows for link clicks. External URLs now open in the system browser, while local or relative file links open in a new SnapDock tab using the existing file-opening workflow.

---

## Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] UI/UX improvement  
- [ ] Documentation update  
- [ ] Refactor / cleanup  

---

## Details

The implementation adds navigation interception in the Electron main process to prevent default window creation for links and to route external URLs through the system browser. In the renderer preview, anchor clicks are now handled explicitly so relative file links resolve against the current document and open the target file in a new tab.

This change is focused on preview link behavior and does not alter the markdown rendering pipeline or markdown-it configuration.

---

## Testing

Describe how you tested your changes:

- [x] Builds successfully  
- [ ] Tested on Windows  
- [x] Tested on Linux  
- [x] No regressions found  

---

## Related Issues

Fixes #184

---

## Additional Notes (optional)

This change ensures the preview behaves more like a modern editor by keeping navigation inside SnapDock for local files and handing off external links to the user’s default browser.