### PR TITLE
feat: basic font and size support, lazy menu layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,25 @@
             <div class="dropdown-panel" id="toolsMenu">
               <button id="updateBtn">Update</button>
               <div class="dropdown-separator"></div>
+              <div class="dropdown-section-label">Editor Font</div>
+              <div class="dropdown-subgroup">
+                <span class="dropdown-subgroup-title">Family</span>
+                <div class="dropdown-chip-row">
+                  <button class="editor-font-family" data-family="mono">Mono</button>
+                  <button class="editor-font-family" data-family="sans">Sans</button>
+                  <button class="editor-font-family" data-family="serif">Serif</button>
+                </div>
+              </div>
+              <div class="dropdown-subgroup">
+                <span class="dropdown-subgroup-title">Size</span>
+                <div class="dropdown-chip-row">
+                  <button class="editor-font-size" data-size="90%">90%</button>
+                  <button class="editor-font-size" data-size="100%">100%</button>
+                  <button class="editor-font-size" data-size="110%">110%</button>
+                  <button class="editor-font-size" data-size="125%">125%</button>
+                </div>
+              </div>
+              <div class="dropdown-separator"></div>
               <button class="theme-option" data-theme="light">Light Theme</button>
               <button class="theme-option" data-theme="dark">Dark Theme</button>
               <button class="theme-option" data-theme="solarized">Solarized</button>

--- a/src/modules/ui/dropdownMenus.js
+++ b/src/modules/ui/dropdownMenus.js
@@ -5,6 +5,7 @@
 
 import { applyTheme } from "./theme.js";
 import { openHelpModal } from "./help.js";
+import { setEditorFont } from "./editorFont.mjs";
 
 // ─── Public API ────────────────────────────────────────────────
 
@@ -67,11 +68,49 @@ export function initToolsDropdown() {
     });
   });
 
+  // ── Editor Font ──
+  attachEditorFontActions();
+
   // ── Help ──
   const helpBtn = document.getElementById("helpBtn");
   if (helpBtn) {
     helpBtn.addEventListener("click", () => openHelpModal());
   }
+}
+
+function attachEditorFontActions() {
+  const editor = document.getElementById("markdownInputMain");
+  const familyButtons = document.querySelectorAll(".editor-font-family");
+  const sizeButtons = document.querySelectorAll(".editor-font-size");
+
+  familyButtons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const family = btn.dataset.family;
+      if (!family) return;
+      setEditorFont(editor, { family });
+      familyButtons.forEach((item) => item.classList.toggle("active", item === btn));
+    });
+  });
+
+  sizeButtons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const size = btn.dataset.size;
+      if (!size) return;
+      setEditorFont(editor, { size });
+      sizeButtons.forEach((item) => item.classList.toggle("active", item === btn));
+    });
+  });
+
+  const currentFont = editor?.dataset?.editorFontFamily || "mono";
+  const currentSize = editor?.dataset?.editorFontSize || "100%";
+
+  familyButtons.forEach((btn) => {
+    btn.classList.toggle("active", btn.dataset.family === currentFont);
+  });
+
+  sizeButtons.forEach((btn) => {
+    btn.classList.toggle("active", btn.dataset.size === currentSize);
+  });
 }
 
 // ─── Update system (moved from system/update.js) ───────────────

--- a/src/modules/ui/editorFont.mjs
+++ b/src/modules/ui/editorFont.mjs
@@ -1,0 +1,93 @@
+const EDITOR_FONT_STORAGE_KEY = "snapdock_editor_font";
+
+export const DEFAULT_EDITOR_FONT_STATE = Object.freeze({
+  family: "mono",
+  size: "100%",
+});
+
+const FONT_FAMILY_MAP = {
+  mono: "Consolas, 'Courier New', monospace",
+  sans: "Inter, 'Segoe UI', Arial, sans-serif",
+  serif: "Georgia, 'Times New Roman', serif",
+};
+
+const SUPPORTED_FAMILIES = Object.keys(FONT_FAMILY_MAP);
+const SUPPORTED_SIZES = ["90%", "100%", "110%", "125%"];
+
+function isSupportedFamily(value) {
+  return typeof value === "string" && SUPPORTED_FAMILIES.includes(value);
+}
+
+function isSupportedSize(value) {
+  return typeof value === "string" && SUPPORTED_SIZES.includes(value);
+}
+
+export function resolveEditorFontState(savedState = null) {
+  if (!savedState || typeof savedState !== "object") {
+    return { ...DEFAULT_EDITOR_FONT_STATE };
+  }
+
+  const family = isSupportedFamily(savedState.family)
+    ? savedState.family
+    : DEFAULT_EDITOR_FONT_STATE.family;
+  const size = isSupportedSize(savedState.size)
+    ? savedState.size
+    : DEFAULT_EDITOR_FONT_STATE.size;
+
+  return { family, size };
+}
+
+export function applyEditorFontToElement(editor, state = DEFAULT_EDITOR_FONT_STATE) {
+  if (!editor) return;
+
+  const resolved = resolveEditorFontState(state);
+  if (editor.style) {
+    editor.style.fontFamily = FONT_FAMILY_MAP[resolved.family] || FONT_FAMILY_MAP.mono;
+    editor.style.fontSize = resolved.size;
+  }
+
+  if (editor.dataset) {
+    editor.dataset.editorFontFamily = resolved.family;
+    editor.dataset.editorFontSize = resolved.size;
+  }
+}
+
+function readStoredState() {
+  if (typeof window === "undefined" || !window.sessionStorage) {
+    return { ...DEFAULT_EDITOR_FONT_STATE };
+  }
+
+  try {
+    const raw = window.sessionStorage.getItem(EDITOR_FONT_STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_EDITOR_FONT_STATE };
+    return resolveEditorFontState(JSON.parse(raw));
+  } catch {
+    return { ...DEFAULT_EDITOR_FONT_STATE };
+  }
+}
+
+function writeStoredState(state) {
+  if (typeof window === "undefined" || !window.sessionStorage) {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(EDITOR_FONT_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Ignore storage errors in non-persistent environments.
+  }
+}
+
+export function initEditorFont({ editor = document.getElementById("markdownInputMain") } = {}) {
+  const state = readStoredState();
+  applyEditorFontToElement(editor, state);
+  return state;
+}
+
+export function setEditorFont(editor, updates = {}) {
+  const currentState = readStoredState();
+  const nextState = resolveEditorFontState({ ...currentState, ...updates });
+  applyEditorFontToElement(editor, nextState);
+  writeStoredState(nextState);
+  return nextState;
+}

--- a/src/modules/ui/editorFont.test.mjs
+++ b/src/modules/ui/editorFont.test.mjs
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DEFAULT_EDITOR_FONT_STATE,
+  resolveEditorFontState,
+  applyEditorFontToElement,
+} from "./editorFont.mjs";
+
+test("resolveEditorFontState defaults to the built-in values", () => {
+  assert.deepEqual(resolveEditorFontState(null), DEFAULT_EDITOR_FONT_STATE);
+  assert.deepEqual(resolveEditorFontState({}), DEFAULT_EDITOR_FONT_STATE);
+});
+
+test("resolveEditorFontState preserves supported family and size values", () => {
+  const state = resolveEditorFontState({ family: "sans", size: "125%" });
+  assert.equal(state.family, "sans");
+  assert.equal(state.size, "125%");
+});
+
+test("applyEditorFontToElement updates the textarea style immediately", () => {
+  const editor = { style: {} };
+  applyEditorFontToElement(editor, { family: "serif", size: "110%" });
+
+  assert.equal(editor.style.fontFamily, "Georgia, 'Times New Roman', serif");
+  assert.equal(editor.style.fontSize, "110%");
+});

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -9,6 +9,7 @@ import { respondToDirtyStateRequest } from "./modules/system/dirtyState.js";
 import { save_all_tabs } from "./modules/file/tabs.js";
 import { initDropdownToggles, initToolsDropdown } from "./modules/ui/dropdownMenus.js";
 import { initMetrics } from "./modules/ui/metrics.js";
+import { initEditorFont } from "./modules/ui/editorFont.mjs";
 
 // Helper
 function byId(id) {
@@ -50,6 +51,7 @@ window.addEventListener("DOMContentLoaded", () => {
   // UI Modules
   initEditorSync();
   initResizer();
+  initEditorFont();
 
   // File Tree
   const fileTreeList = byId("fileTreeList");

--- a/src/styles/components/editor.css
+++ b/src/styles/components/editor.css
@@ -15,8 +15,9 @@
   border: none;
   outline: none;
   resize: none;
-  font-family: monospace;
+  font-family: Consolas, 'Courier New', monospace;
   font-size: 1em;
+  line-height: 1.55;
   background: inherit;
   color: inherit;
   box-sizing: border-box;

--- a/src/styles/components/header.css
+++ b/src/styles/components/header.css
@@ -178,6 +178,48 @@ body.dark-theme .title-row {
   margin: 4px 8px;
 }
 
+.dropdown-section-label {
+  padding: 6px 14px 2px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--editor-text-secondary);
+}
+
+.dropdown-subgroup {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 4px 12px 8px;
+}
+
+.dropdown-subgroup-title {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--editor-text-secondary);
+}
+
+.dropdown-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.dropdown-chip-row button {
+  border: 1px solid var(--tab-border);
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 0.74rem;
+  background: transparent;
+}
+
+.dropdown-chip-row button.active {
+  background: var(--tab-active-bg);
+  border-color: var(--tab-accent);
+  color: var(--editor-text);
+}
+
 /* ─── Preview mode toggle (right side) ─── */
 #previewToggleBtn {
   background: var(--tab-idle-bg);


### PR DESCRIPTION
# Pull Request

Thank you for contributing to SnapDock!  
Please complete the sections below to help us review your PR.

---

## Summary

this added font and scale support in the tools menu, while positioning was lazy the features work

---

## Type of Change

- [ ] Bug fix  
- [x] New feature  
- [x] UI/UX improvement  
- [ ] Documentation update  
- [ ] Refactor / cleanup  

---

## Details

Explain the implementation, any decisions made, and any side effects.
adding some core options for now including scaling from 90% to 125% and basic in editor window fonts.

---

## Testing

Describe how you tested your changes:

- [x] Builds successfully  
- [ ] Tested on Windows  
- [x] Tested on Linux  
- [x] No regressions found  

---

## Related Issues

Link any related issues or discussions:

`Fixes #123` or `Related to #456`
#177 

---

## Additional Notes (optional)

Anything else reviewers should know.
im not overly happy with the menu layout on this one but the issue was solved to expectation. recommend a new issue addressing the cluttered tool menu