### PR TITLE
feat: close project

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
                 <button id="saveAllBtnTop">Save All</button>
                 <button id="exportPdfBtn">Export</button>
                 <div class="dropdown-separator"></div>
-                <button id="closeProjectBtn" class="dropdown-item-stub" title="Coming soon">Close Project</button>
+                <button id="closeProjectBtn">Close Project</button>
               </div>
             </div>
 

--- a/main.js
+++ b/main.js
@@ -43,6 +43,7 @@ let currentWorkspacePath = null;
 let mainWindow;
 let lastKnownDirtyState = false;
 let forceClose = false;
+let relaunchAfterClose = false;
 let spellcheckEnabled = true;
 const spellcheckConfigPath = path.join(app.getPath("userData"), "spellcheck-config.json");
 
@@ -84,6 +85,20 @@ function applySpellcheckState(enabled, targetWindow = mainWindow) {
   targetWindow.webContents.session.setSpellCheckerLanguages(
     enabled && preferredLanguage ? [preferredLanguage] : []
   );
+}
+
+function finishWindowClose() {
+  if (relaunchAfterClose) {
+    ipcMain.once("workspace:clear-for-close:result", () => {
+      app.relaunch();
+      app.exit(0);
+    });
+    mainWindow.webContents.send("workspace:clear-for-close:request");
+    return;
+  }
+
+  forceClose = true;
+  mainWindow.close();
 }
 
 function createWindow() {
@@ -194,9 +209,9 @@ function createWindow() {
           // User chose "Save All"
           const onResult = (_event, result) => {
             if (result?.ok) {
-              forceClose = true;
-              mainWindow.close();
+              finishWindowClose();
             } else {
+              relaunchAfterClose = false;
               dialog.showMessageBox(mainWindow, {
                 type: "error",
                 buttons: ["OK"],
@@ -214,15 +229,15 @@ function createWindow() {
 
         if (choice === 2) {
           // User chose "Discard Changes"
-          forceClose = true;
-          mainWindow.close();
+          finishWindowClose();
         }
 
-        // choice === 0 (Cancel): do nothing, keep app open
+        if (choice === 0) {
+          relaunchAfterClose = false;
+        }
       } else {
         // Clean workspace -> safe to close
-        forceClose = true;
-        mainWindow.close();
+        finishWindowClose();
       }
     }, 50);
   });
@@ -458,6 +473,12 @@ ipcMain.handle("get-version", async () => {
 
   ipcMain.on("window:close", () => {
     if (mainWindow) mainWindow.close();
+  });
+
+  ipcMain.on("workspace:close-project", () => {
+    if (!mainWindow || mainWindow.isDestroyed()) return;
+    relaunchAfterClose = true;
+    mainWindow.close();
   });
 
   ipcMain.handle("window:isMaximized", () => {

--- a/src/modules/ui/app.js
+++ b/src/modules/ui/app.js
@@ -93,6 +93,13 @@ export function initApp() {
     });
   }
 
+  const closeProjectBtn = document.getElementById("closeProjectBtn");
+  if (closeProjectBtn) {
+    closeProjectBtn.addEventListener("click", () => {
+      window.electronAPI.closeProject();
+    });
+  }
+
 
   // 7️⃣ Version tag
   setVersionTag(versionTag);

--- a/src/preload.js
+++ b/src/preload.js
@@ -42,6 +42,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke("open-file-by-path", path),
   resolveLocalAttachment,
 
+  // Close the current workspace by restarting after the dirty-state guard.
+  closeProject: () => ipcRenderer.send("workspace:close-project"),
+
   // Workspace watcher
   onWorkspaceUpdated: (callback) =>
     ipcRenderer.on("workspace-updated", () => callback()),
@@ -124,4 +127,10 @@ contextBridge.exposeInMainWorld("workspaceAPI", {
 
   sendSaveAllForCloseResult: (result) =>
     ipcRenderer.send("workspace:save-all-for-close:result", result),
+
+  onClearForCloseRequest: (callback) =>
+    ipcRenderer.on("workspace:clear-for-close:request", () => callback()),
+
+  sendClearForCloseResult: () =>
+    ipcRenderer.send("workspace:clear-for-close:result"),
 });

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -9,6 +9,7 @@ import { respondToDirtyStateRequest } from "./modules/system/dirtyState.js";
 import { save_all_tabs } from "./modules/file/tabs.js";
 import { initDropdownToggles, initToolsDropdown } from "./modules/ui/dropdownMenus.js";
 import { initMetrics } from "./modules/ui/metrics.js";
+import { clearWorkspace } from "./modules/file/workspace.js";
 
 // Helper
 function byId(id) {
@@ -36,6 +37,11 @@ window.workspaceAPI.onSaveAllForCloseRequest(async() => {
     });
   }
 })
+
+window.workspaceAPI.onClearForCloseRequest(() => {
+  clearWorkspace();
+  window.workspaceAPI.sendClearForCloseResult();
+});
 
 // --- MAIN BOOTSTRAP ---
 window.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
# Pull Request

Thank you for contributing to SnapDock!  
Please complete the sections below to help us review your PR.

---

## Summary

Implemented the "Close Project" / workspace option under the Save tab to allow users to reset their active workspace directory back to a clean default state.

---

## Type of Change

- [ ] Bug fix  
- [x] New feature  
- [x] UI/UX improvement  
- [ ] Documentation update  
- [ ] Refactor / cleanup  

---

## Details

- Enabled the previously grayed-out "Close Project" option in the main menu/Save tab.
- Implemented workspace clearing by triggering a clean application state reset/relaunch, clearing open project paths and active workspace file trees.
- Note: This application restart approach serves as a straightforward implementation for v3.x. Future work on persistent session state will need to account for this reset trigger.

---

## Testing

Describe how you tested your changes:

- [x] Builds successfully  
- [ ] Tested on Windows  
- [x] Tested on Linux  
- [x] No regressions found  

---

## Related Issues

Fixes #223

---

## Additional Notes (optional)

Tested clicking "Close Project" from the menu bar to verify that active file paths, open tab buffers, and sidebar trees unmount cleanly without hanging process handles.