### PR TITLE
fix: prevent update IPC listener leaks

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -87,11 +87,15 @@ contextBridge.exposeInMainWorld("electronAPI", {
   installUpdate: () =>
     ipcRenderer.invoke("update:install"),
 
-  onUpdateAvailable: (callback) =>
-    ipcRenderer.on("update:available", (_, info) => callback(info)),
+  onUpdateAvailable: (callback) => {
+    ipcRenderer.removeAllListeners("update:available");
+    return ipcRenderer.on("update:available", (_, info) => callback(info));
+  },
 
-  onUpdateNone: (callback) =>
-    ipcRenderer.on("update:none", () => callback()),
+  onUpdateNone: (callback) => {
+    ipcRenderer.removeAllListeners("update:none");
+    return ipcRenderer.on("update:none", () => callback());
+  },
 
   onUpdateProgress: (callback) => {
     // FIX M6: remove existing listeners before adding new one to prevent leaks


### PR DESCRIPTION
Fixes the IPC listener leak in onUpdateAvailable and onUpdateNone.

Both listeners now remove existing listeners before registering a new one, matching the pattern already used by the other update events.

Tests:

node --check src/preload.js
node test/markdown-render.mjs
node tests/find.test.js

Closes #238