### PR TITLE
fix: support Tab indentation in Markdown editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "start": "electron .",
     "md:test": "node test/markdown-render.mjs",
-    "test": "npm run md:test && node tests/find.test.js && node tests/link-navigation.test.js",
+    "test": "npm run md:test && node tests/find.test.js && node tests/link-navigation.test.js && node --test tests/editor-indent.test.mjs",
     "build:dev": "node scripts/build-dev.js",
     "build:test": "node scripts/build-test.js",
     "build:win": "node scripts/build-win.js",

--- a/src/modules/ui/editorIndent.js
+++ b/src/modules/ui/editorIndent.js
@@ -1,0 +1,118 @@
+export const MARKDOWN_INDENT = "    ";
+
+function lineStartAt(value, position) {
+  return value.lastIndexOf("\n", Math.max(0, position - 1)) + 1;
+}
+
+function selectedLineRange(value, selectionStart, selectionEnd) {
+  const start = lineStartAt(value, selectionStart);
+  let effectiveEnd = selectionEnd;
+
+  // A selection ending immediately after a newline does not include the next
+  // line, matching the behaviour users expect from code editors.
+  if (selectionEnd > selectionStart && value[selectionEnd - 1] === "\n") {
+    effectiveEnd -= 1;
+  }
+
+  const newline = value.indexOf("\n", effectiveEnd);
+  const end = newline === -1 ? value.length : newline;
+  return { start, end };
+}
+
+function outdentWidth(value, lineStart) {
+  if (value[lineStart] === "\t") return 1;
+
+  let spaces = 0;
+  while (spaces < MARKDOWN_INDENT.length && value[lineStart + spaces] === " ") {
+    spaces += 1;
+  }
+  return spaces;
+}
+
+function mapPositionAfterRemovals(position, removals) {
+  let mapped = position;
+  for (const removal of removals) {
+    if (position <= removal.from) continue;
+    mapped -= Math.min(removal.count, position - removal.from);
+  }
+  return mapped;
+}
+
+export function indentMarkdown(value, selectionStart, selectionEnd, outdent = false) {
+  const source = value ?? "";
+  const start = Math.max(0, Math.min(selectionStart ?? 0, source.length));
+  const end = Math.max(start, Math.min(selectionEnd ?? start, source.length));
+
+  if (!outdent && start === end) {
+    return {
+      value: source.slice(0, start) + MARKDOWN_INDENT + source.slice(end),
+      selectionStart: start + MARKDOWN_INDENT.length,
+      selectionEnd: start + MARKDOWN_INDENT.length,
+      changed: true,
+    };
+  }
+
+  const range = selectedLineRange(source, start, end);
+  const lineStarts = [range.start];
+  for (let index = range.start; index < range.end; index += 1) {
+    if (source[index] === "\n") lineStarts.push(index + 1);
+  }
+
+  if (!outdent) {
+    let result = source;
+    for (let index = lineStarts.length - 1; index >= 0; index -= 1) {
+      const lineStart = lineStarts[index];
+      result = result.slice(0, lineStart) + MARKDOWN_INDENT + result.slice(lineStart);
+    }
+
+    return {
+      value: result,
+      selectionStart: start === range.start ? start : start + MARKDOWN_INDENT.length,
+      selectionEnd: end + MARKDOWN_INDENT.length * lineStarts.length,
+      changed: true,
+    };
+  }
+
+  const removals = lineStarts
+    .map(from => ({ from, count: outdentWidth(source, from) }))
+    .filter(removal => removal.count > 0);
+
+  if (!removals.length) {
+    return { value: source, selectionStart: start, selectionEnd: end, changed: false };
+  }
+
+  let result = source;
+  for (let index = removals.length - 1; index >= 0; index -= 1) {
+    const removal = removals[index];
+    result = result.slice(0, removal.from) + result.slice(removal.from + removal.count);
+  }
+
+  return {
+    value: result,
+    selectionStart: mapPositionAfterRemovals(start, removals),
+    selectionEnd: mapPositionAfterRemovals(end, removals),
+    changed: true,
+  };
+}
+
+export function initEditorIndent(editor = document.getElementById("markdownInputMain")) {
+  if (!editor) return;
+
+  editor.addEventListener("keydown", event => {
+    if (event.key !== "Tab" || event.ctrlKey || event.metaKey || event.altKey) return;
+
+    event.preventDefault();
+    const result = indentMarkdown(
+      editor.value,
+      editor.selectionStart,
+      editor.selectionEnd,
+      event.shiftKey
+    );
+
+    if (!result.changed) return;
+
+    editor.setRangeText(result.value, 0, editor.value.length, "preserve");
+    editor.setSelectionRange(result.selectionStart, result.selectionEnd);
+    editor.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -11,6 +11,7 @@ import { initDropdownToggles, initToolsDropdown } from "./modules/ui/dropdownMen
 import { initMetrics } from "./modules/ui/metrics.js";
 import { initEditorFont } from "./modules/ui/editorFont.mjs";
 import { clearWorkspace } from "./modules/file/workspace.js";
+import { initEditorIndent } from "./modules/ui/editorIndent.js";
 
 // Helper
 function byId(id) {
@@ -58,6 +59,7 @@ window.addEventListener("DOMContentLoaded", () => {
   initEditorSync();
   initResizer();
   initEditorFont();
+  initEditorIndent();
 
   // File Tree
   const fileTreeList = byId("fileTreeList");

--- a/tests/editor-indent.test.mjs
+++ b/tests/editor-indent.test.mjs
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { indentMarkdown, MARKDOWN_INDENT } from "../src/modules/ui/editorIndent.js";
+
+test("Tab inserts four spaces at the caret", () => {
+  const result = indentMarkdown("- item", 2, 2);
+  assert.equal(result.value, `- ${MARKDOWN_INDENT}item`);
+  assert.equal(result.selectionStart, 2 + MARKDOWN_INDENT.length);
+  assert.equal(result.selectionEnd, 2 + MARKDOWN_INDENT.length);
+});
+
+test("Tab indents every selected line", () => {
+  const source = "- first\n- second\n- third";
+  const result = indentMarkdown(source, 0, source.length);
+  assert.equal(result.value, "    - first\n    - second\n    - third");
+  assert.equal(result.selectionStart, 0);
+  assert.equal(result.selectionEnd, source.length + 12);
+});
+
+test("a selection ending after a newline does not indent the next line", () => {
+  const source = "one\ntwo\nthree";
+  const result = indentMarkdown(source, 0, 4);
+  assert.equal(result.value, "    one\ntwo\nthree");
+});
+
+test("Shift+Tab removes up to four leading spaces from the current line", () => {
+  const result = indentMarkdown("    - nested", 8, 8, true);
+  assert.equal(result.value, "- nested");
+  assert.equal(result.selectionStart, 4);
+  assert.equal(result.selectionEnd, 4);
+});
+
+test("Shift+Tab outdents selected lines with mixed indentation", () => {
+  const source = "    one\n  two\n\tthree";
+  const result = indentMarkdown(source, 0, source.length, true);
+  assert.equal(result.value, "one\ntwo\nthree");
+  assert.equal(result.selectionStart, 0);
+  assert.equal(result.selectionEnd, "one\ntwo\nthree".length);
+});
+
+test("Shift+Tab leaves an unindented line unchanged", () => {
+  const result = indentMarkdown("plain", 2, 2, true);
+  assert.deepEqual(result, {
+    value: "plain",
+    selectionStart: 2,
+    selectionEnd: 2,
+    changed: false,
+  });
+});


### PR DESCRIPTION
## Summary

- override Tab only inside the Markdown textarea so it inserts four spaces instead of moving focus
- support Shift+Tab outdent for the current line
- indent and outdent multiline selections as a block
- preserve normal Tab navigation outside the editor
- dispatch the normal input event so dirty state, metrics, tabs, and live preview stay synchronized

## Validation

- manually tested and confirmed in the packaged app
- 6 editor indentation regression tests pass
- Markdown renderer tests pass
- find tests pass
- renderer bundle succeeds

## Notes

The existing link-navigation tests remain platform-specific and fail on Windows because they assert POSIX path output; this is unrelated to this change.